### PR TITLE
Refactors ordering alg to account for snapshot update

### DIFF
--- a/__tests__/services/playlistMovementCalculator.test.js
+++ b/__tests__/services/playlistMovementCalculator.test.js
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+const playlistMovementCalculator = require('../../src/services/playlistMovementCalculator')
+const spotifyPlaylistFixtures = require('../../__fixtures__/playlistItems.fixture')
+
+describe('Movements should be calculated based on the current playlist and the ordered playlist', () => {
+  it('The movement calculation for a playlist that doesnt have any songs should return empty array of movements ', async () => {
+    const actualPlaylist = spotifyPlaylistFixtures.generatePlaylistItems()
+    const toBePlaylist = spotifyPlaylistFixtures.generatePlaylistItems()
+
+    const calculatedMovements = playlistMovementCalculator.getPlaylistReorderMovements(actualPlaylist, toBePlaylist)
+
+    expect(calculatedMovements).toStrictEqual([])
+  })
+
+  it('The movement calculation for a playlist that have only one song should return empty array of movements', async () => {
+    const actualPlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }])
+    const toBePlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }])
+
+    const calculatedMovements = playlistMovementCalculator.getPlaylistReorderMovements(actualPlaylist, toBePlaylist)
+
+    expect(calculatedMovements.map(item => item.track.id)).toStrictEqual([])
+  })
+
+  it('The movement calculation for a [A1, A2, B1] that needs to become [A1, A2, B1] should be []', async () => {
+    const actualPlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }])
+    const toBePlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }])
+
+    const calculatedMovements = playlistMovementCalculator.getPlaylistReorderMovements(actualPlaylist, toBePlaylist)
+
+    expect(calculatedMovements.map(item => item.track.id)).toStrictEqual([])
+  })
+
+  it('The movement calculation for a [B1, A1] that needs to become [A1, B1] should be [{1,0}]', async () => {
+    const actualPlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'B1' }, { trackId: 'A1' }])
+    const toBePlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'B1' }])
+
+    const calculatedMovements = playlistMovementCalculator.getPlaylistReorderMovements(actualPlaylist, toBePlaylist)
+
+    expect(calculatedMovements).toStrictEqual([{ from: 1, to: 0 }])
+  })
+
+  it('The movement calculation for a [A1, A2, B1, A3, B2] that needs to become [A1, B1, A2, B2, A3] should be [{2,1},{4,3}]', async () => {
+    const actualPlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'B1' }, { trackId: 'A3' }, { trackId: 'B2' }])
+    const toBePlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'B1' }, { trackId: 'A2' }, { trackId: 'B2' }, { trackId: 'A3' }])
+
+    const calculatedMovements = playlistMovementCalculator.getPlaylistReorderMovements(actualPlaylist, toBePlaylist)
+
+    expect(calculatedMovements).toStrictEqual([{ from: 2, to: 1 }, { from: 4, to: 3 }])
+  })
+})

--- a/__tests__/services/playlistOrderingService.test.js
+++ b/__tests__/services/playlistOrderingService.test.js
@@ -6,7 +6,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist that doesnt have any songs yet should be sorted without throwing any exception ', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems()
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist)
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist)
 
     expect(reorderedPlaylist).toStrictEqual([])
   })
@@ -14,7 +14,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1*] should become [A1*] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1'])
   })
@@ -22,7 +22,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1*, A2, A3] should become [A1*, A2, A3] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'A2', 'A3'])
   })
@@ -33,7 +33,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
         { trackId: 'B1' },
         { trackId: 'A2' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'A2'])
   })
@@ -49,7 +49,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
         { trackId: 'A2' }]
     )
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'C1', 'A2', 'B2', 'C2', 'C3'])
   })
@@ -62,7 +62,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
         { trackId: 'B1', added_at: '2019-12-27T01:30:02Z' }]
     )
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A2', 'B2', 'A1', 'B1'])
   })
@@ -74,7 +74,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
         { trackId: 'B1', added_at: '2019-12-27T01:30:02Z' }]
     )
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'C1'])
   })
@@ -82,7 +82,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1, B1, A2*, C1] should become [A1, B1, A2*, C1] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'B1' }, { trackId: 'A2' }, { trackId: 'C1' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[3])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[3])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'A2', 'C1'])
   })
@@ -90,7 +90,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1, B1, A2*] should become [A1, B1, A2*] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'B1' }, { trackId: 'A2' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[3])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[3])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'A2'])
   })
@@ -98,7 +98,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1, A2*, A3, B1] should become [A1, A2*, B1, A3] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }, { trackId: 'B1' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[1])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[1])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'A2', 'B1', 'A3'])
   })
@@ -106,7 +106,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1*, B1, B2, B3, A2] should become [A1*,B1, A2, B2, B3] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'B1' }, { trackId: 'B2' }, { trackId: 'B3' }, { trackId: 'A2' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, playlist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, playlist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'B1', 'A2', 'B2', 'B3'])
   })
@@ -114,7 +114,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
   it('A playlist [A1, A2, A3, B1] whose owner is not playing any track should become [A1, A2, A3, B1] after reordering', async () => {
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }, { trackId: 'B1' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, {})
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, {})
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'A2', 'A3', 'B1'])
   })
@@ -123,7 +123,7 @@ describe('When ordering a playlist that has already a song playing, the algorith
     const playlist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'A1' }, { trackId: 'A2' }, { trackId: 'A3' }, { trackId: 'B1' }])
     const otherPlaylist = spotifyPlaylistFixtures.generatePlaylistItems([{ trackId: 'N1' }])
 
-    const reorderedPlaylist = playlistOrderingService.reorder(playlist, otherPlaylist[0])
+    const reorderedPlaylist = playlistOrderingService.reorderPlaylist(playlist, otherPlaylist[0])
 
     expect(reorderedPlaylist.map(item => item.track.id)).toStrictEqual(['A1', 'A2', 'A3', 'B1'])
   })

--- a/src/clients/SpotifyClientWrapper.js
+++ b/src/clients/SpotifyClientWrapper.js
@@ -73,7 +73,8 @@ class SpotifyClientWrapper {
   }
 
   reorderTracksInPlaylist (playlistId, positionInCurentPlaylist, positionInOrderedPlaylist, options) {
-    this.spotifyApi.reorderTracksInPlaylist(playlistId, positionInCurentPlaylist, positionInOrderedPlaylist, options)
+    return this.spotifyApi.reorderTracksInPlaylist(playlistId, positionInCurentPlaylist, positionInOrderedPlaylist, options)
+      .then(data => data?.body?.snapshot_id ?? '')
       .catch(err => {
         console.error(`Error while reordering Tracks in Playlists!\nError:${err}`)
       })

--- a/src/services/playlistManagementService.js
+++ b/src/services/playlistManagementService.js
@@ -1,5 +1,6 @@
 const spotifyAuthenticationService = require('./spotifyAuthenticationService')
 const playlistOrderingService = require('./playlistOrderingService')
+const playlistMovementCalculator = require('./playlistMovementCalculator')
 
 const ResourceDoesNotBelongToEntityError = require('../errors/ResourceDoesNotBelongToEntityError')
 const ResourceNotFoundError = require('../errors/ResourceNotFoundError')
@@ -10,20 +11,16 @@ async function orderPlaylist (playlistId, refreshToken) {
   const spotifyAuthenticatedClient = await spotifyAuthenticationService.provideAuthenticatedClient(refreshToken)
   let currenPlaylist = spotifyAuthenticatedClient.retrievePlaylistTracks(playlistId)
   let currentTrackId = spotifyAuthenticatedClient.retrieveCurrentTrackId()
-  const playlistSnapshotId = spotifyAuthenticatedClient.retrievePlaylistSnapshotId(playlistId);
+  let playlistSnapshotId = spotifyAuthenticatedClient.retrievePlaylistSnapshotId(playlistId);
   [currenPlaylist, currentTrackId] = await Promise.all([currenPlaylist, currentTrackId]).catch((err) => { throw err })
   const currentPlaylistTracks = currenPlaylist.items
   const currentTrack = currentPlaylistTracks.find((trackInfo) => trackInfo.track.id === currentTrackId) ?? {}
-  const nextTrackPosition = currentPlaylistTracks.indexOf(currentTrack) + 1
 
-  const reorderedPlaylistTracks = playlistOrderingService.reorder(currentPlaylistTracks, currentTrack)
+  const reorderedPlaylistTracks = playlistOrderingService.reorderPlaylist(currentPlaylistTracks, currentTrack)
+  const movements = playlistMovementCalculator.getPlaylistReorderMovements(currentPlaylistTracks, reorderedPlaylistTracks)
 
-  for (const track of currentPlaylistTracks.slice(nextTrackPosition)) {
-    const positionInCurentPlaylist = currentPlaylistTracks.indexOf(track)
-    const positionInOrderedPlaylist = reorderedPlaylistTracks.indexOf(track)
-    if (positionInCurentPlaylist !== positionInOrderedPlaylist) {
-      spotifyAuthenticatedClient.reorderTracksInPlaylist(playlistId, positionInCurentPlaylist, positionInOrderedPlaylist, { snapshot_id: await playlistSnapshotId })
-    }
+  for (const movement of movements) {
+    playlistSnapshotId = spotifyAuthenticatedClient.reorderTracksInPlaylist(playlistId, movement.from, movement.to, { snapshot_id: await playlistSnapshotId })
   }
 }
 
@@ -36,7 +33,7 @@ async function managePlaylist (playlistId, refreshToken) {
 
   const timer = setInterval(function () {
     module.exports.orderPlaylist(playlistId, refreshToken)
-  }, 30 * 1000)
+  }, 100 * 1000)
   managedPlaylists.add(refreshToken, { playlistId, timer })
 }
 

--- a/src/services/playlistMovementCalculator.js
+++ b/src/services/playlistMovementCalculator.js
@@ -1,0 +1,29 @@
+function getPlaylistReorderMovements (currentPlaylistTracks, toBePlaylistTracks) {
+  const movements = []
+  const movingPlaylistTracks = [...currentPlaylistTracks]
+  for (const positionInToBePlaylist of toBePlaylistTracks.keys()) {
+    const toBeTrackEntry = toBePlaylistTracks[positionInToBePlaylist]
+    if (areTracksDifferent(movingPlaylistTracks[positionInToBePlaylist], toBeTrackEntry)) {
+      const positionInCurrentPlaylist = movingPlaylistTracks.findIndex(currentTrackEntry => areTracksEqual(currentTrackEntry, toBeTrackEntry))
+      movements.push({ from: positionInCurrentPlaylist, to: positionInToBePlaylist })
+      moveTrack(movingPlaylistTracks, positionInCurrentPlaylist, positionInToBePlaylist)
+    }
+  }
+  return movements
+}
+
+function moveTrack (playlistTracks, fromPosition, toPosition) {
+  const track = playlistTracks[fromPosition]
+  playlistTracks.splice(fromPosition, 1)
+  playlistTracks.splice(toPosition, 0, track)
+}
+
+function areTracksDifferent (entry1, entry2) {
+  return entry1.track.id !== entry2.track.id && entry1.added_by.id !== entry2.added_by.id
+}
+
+function areTracksEqual (entry1, entry2) {
+  return entry1.track.id === entry2.track.id && entry1.added_by.id === entry2.added_by.id
+}
+
+module.exports.getPlaylistReorderMovements = getPlaylistReorderMovements

--- a/src/services/playlistOrderingService.js
+++ b/src/services/playlistOrderingService.js
@@ -1,20 +1,20 @@
-function reorder (playlistTracks, currentTrack) {
-  const currentTrackInfo = defineCurrentTrackInformation(playlistTracks, currentTrack)
-  if (currentTrackInfo.userId) {
-    const userOrder = defineMidCycleUserOrder(playlistTracks, currentTrackInfo)
-    const numberOfTracksPerUser = calculateNumberOfTracksPerUser(userOrder, playlistTracks)
-    return definePlaylistOrder(playlistTracks, userOrder, numberOfTracksPerUser, currentTrackInfo)
-  } else {
-    return playlistTracks
-  }
-}
-
 function defineCurrentTrackInformation (playlistTracks, currentTrack) {
   if (playlistTracks.indexOf(currentTrack) >= 0) {
     return { position: playlistTracks.indexOf(currentTrack), userId: currentTrack.added_by.id }
   } else {
     return {}
   }
+}
+
+function reorderPlaylist (playlistTracks, currentTrack) {
+  const currentTrackInfo = defineCurrentTrackInformation(playlistTracks, currentTrack)
+  let reorderedPlaylist = [...playlistTracks]
+  if (currentTrackInfo.userId) {
+    const userOrder = defineMidCycleUserOrder(playlistTracks, currentTrackInfo)
+    const numberOfTracksPerUser = calculateNumberOfTracksPerUser(userOrder, playlistTracks)
+    reorderedPlaylist = definePlaylistOrder(playlistTracks, userOrder, numberOfTracksPerUser, currentTrackInfo)
+  }
+  return reorderedPlaylist
 }
 
 function defineMidCycleUserOrder (playlistTracks, currentTrackInfo) {
@@ -56,4 +56,4 @@ function definePlaylistOrder (playlistTracks, userOrder, numberOfTracksPerUser, 
   return playlistTracks.slice(0, currentTrackInfo.position + 1).concat(orderedPlaylistTracks.filter(Boolean))
 }
 
-module.exports.reorder = reorder
+module.exports.reorderPlaylist = reorderPlaylist


### PR DESCRIPTION
Spotify was not managing to reorder playlists when the reorder commands sent were using the same snapshot id. Response from  Spotify would be a 502. These changes solve that by taking into account the snapshot ids 