### PR TITLE
Unit tests enchanced for Playlist Management and Managed Playlists

### DIFF
--- a/__tests__/repositories/managedPlaylists.test.js
+++ b/__tests__/repositories/managedPlaylists.test.js
@@ -3,9 +3,14 @@ const PersistenceError = require("../../src/errors/PersistenceError");
 
 const managedPlaylists = require("../../src/repositories/managedPlaylists");
 
+const DUMMY_TIMER = {
+  timer: expect.anything(),
+  orderingRunning: expect.anything(),
+};
+
 it("Geting a playlist timer whose refresh token was added previously should return the timer", async () => {
   // Arrange
-  managedPlaylists.add("RFT1", { playlistId: "P1", timer: expect.anything() });
+  managedPlaylists.add("RFT1", "P1", DUMMY_TIMER);
 
   // Act
   const authenticationData = managedPlaylists.get("RFT1", "P1");
@@ -40,11 +45,13 @@ it("Geting a playlist timer whose refreshToken is not a string should return a f
 
 it("Adding a playlist whose playlistId is different than a string should throw PersistenceError error", async () => {
   // Act - Assert
-  expect(() => managedPlaylists.add(undefined, expect.anything())).toThrow(
-    PersistenceError
-  );
-  expect(() => managedPlaylists.add(undefined, expect.anything())).toThrow(
-    "Unable to persist a playlist timer with playlistId different than a string. Instead it was [undefined]"
+  expect(() =>
+    managedPlaylists.add(undefined, expect.anything(), expect.anything())
+  ).toThrow(PersistenceError);
+  expect(() =>
+    managedPlaylists.add(undefined, expect.anything(), expect.anything())
+  ).toThrow(
+    "Unable to persist a playlist timer with refreshToken different than a string. Instead it was [undefined]"
   );
 });
 
@@ -62,9 +69,9 @@ it("Geting playlist timer that was removed should return undefined", async () =>
 
 it("Geting all playlist ids for refresh token should return an array of playlistIds", async () => {
   // Arrange
-  managedPlaylists.add("RFT3", { playlistId: "P1", timer: expect.anything() });
-  managedPlaylists.add("RFT3", { playlistId: "P2", timer: expect.anything() });
-  managedPlaylists.add("RFT3", { playlistId: "P3", timer: expect.anything() });
+  managedPlaylists.add("RFT3", "P1", DUMMY_TIMER);
+  managedPlaylists.add("RFT3", "P2", DUMMY_TIMER);
+  managedPlaylists.add("RFT3", "P3", DUMMY_TIMER);
 
   // Act
   const playlistIds = managedPlaylists.getAllPlaylistIds("RFT3");

--- a/src/repositories/managedPlaylists.js
+++ b/src/repositories/managedPlaylists.js
@@ -1,10 +1,10 @@
 const managedPlaylists = {};
 const PersistenceError = require("../errors/PersistenceError");
 
-function add(refreshToken, item) {
+function add(refreshToken, playlistId, item) {
   if (typeof refreshToken !== "string") {
     throw new PersistenceError(
-      `Unable to persist a playlist timer with playlistId different than a string. Instead it was [${typeof playlistId}]`
+      `Unable to persist a playlist timer with refreshToken different than a string. Instead it was [${typeof refreshToken}]`
     );
   }
 
@@ -12,7 +12,7 @@ function add(refreshToken, item) {
     managedPlaylists[refreshToken] = new Map();
   }
 
-  managedPlaylists[refreshToken].set(item.playlistId, item.timer);
+  managedPlaylists[refreshToken].set(playlistId, {...item});
 }
 
 function get(refreshToken, playlistId) {

--- a/src/services/playlistManagementService.js
+++ b/src/services/playlistManagementService.js
@@ -60,8 +60,8 @@ async function managePlaylist(playlistId, refreshToken) {
 }
 
 async function unmanagePlaylist(playlistId, refreshToken) {
-  await validatePlaylistBelongsToUser(playlistId, refreshToken);
-  await validatePlaylistIsRegistred(playlistId);
+  await module.exports.validatePlaylistBelongsToUser(playlistId, refreshToken);
+  await module.exports.validatePlaylistIsRegistred(playlistId);
 
   clearInterval(managedPlaylists.get(playlistId));
   managedPlaylists.remove(playlistId);
@@ -94,4 +94,6 @@ module.exports = {
   managePlaylist,
   unmanagePlaylist,
   getManagedPlaylistsIds,
+  validatePlaylistBelongsToUser,
+  validatePlaylistIsRegistred
 };


### PR DESCRIPTION
While developing unit tests for https://github.com/yurigava/democratic-spotify-playlist/issues/26 ,I found out that it would be very difficult without a minor/medium refactoring, therefore I created https://github.com/yurigava/democratic-spotify-playlist/issues/40 so I could refactor it just enough to accommodate the new unit test